### PR TITLE
separate link lines from textgroups

### DIFF
--- a/src/lib/parser.js
+++ b/src/lib/parser.js
@@ -1,9 +1,10 @@
-import React from 'react';
-import { View } from 'react-native';
-import tokensToAST from './util/tokensToAST';
-import { stringToTokens } from './util/stringToTokens';
-import { cleanupTokens } from './util/cleanupTokens';
-import groupTextTokens from './util/groupTextTokens';
+import React from 'react'
+import { View } from 'react-native'
+import tokensToAST from './util/tokensToAST'
+import { stringToTokens } from './util/stringToTokens'
+import { cleanupTokens } from './util/cleanupTokens'
+import groupTextTokens from './util/groupTextTokens'
+import cleanRedundantSoftBreaks from './util/cleanRedundantSoftBreaks'
 
 /**
  *
@@ -13,11 +14,11 @@ import groupTextTokens from './util/groupTextTokens';
  * @return {View}
  */
 export default function parser(source, renderer, markdownIt) {
-  let tokens = stringToTokens(source, markdownIt);
-  tokens = cleanupTokens(tokens);
-  tokens = groupTextTokens(tokens);
+  let tokens = stringToTokens(source, markdownIt)
+  tokens = cleanupTokens(tokens)
+  tokens = groupTextTokens(tokens)
+  let astTree = tokensToAST(tokens)
+  astTree = cleanRedundantSoftBreaks(astTree)
 
-  const astTree = tokensToAST(tokens);
-
-  return renderer(astTree);
+  return renderer(astTree)
 }

--- a/src/lib/util/cleanRedundantSoftBreaks.js
+++ b/src/lib/util/cleanRedundantSoftBreaks.js
@@ -1,0 +1,33 @@
+const breakTypes = ['softbreak', 'hardbreak']
+
+// removes all line breaking elements that are left overs from links manipulation,
+// now redundant because different closing a text group already breaks line.
+export default function cleanRedundantSoftBreaks(astTree) {
+    astTree.forEach(x => {
+        if (x.children) {
+            // remove all textgroups that contain only a break element
+            x.children = x.children.filter(
+                el =>
+                    !(
+                        el.type === 'textgroup' &&
+                        el.children?.length === 1 &&
+                        breakTypes.includes(el.children[0].type)
+                    ),
+            )
+            // remove all first or last break elements in a textgroup
+            x.children
+                .filter(el => el.type === 'textgroup' && el.children)
+                .forEach(el => {
+                    if (breakTypes.includes(el.children[0]?.type)) {
+                        el.children.shift()
+                    }
+                    if (
+                      breakTypes.includes(el.children[el.children.length - 1]?.type)
+                    ) {
+                        el.children.pop()
+                    }
+                })
+        }
+    })
+    return astTree
+}

--- a/src/lib/util/groupTextTokens.js
+++ b/src/lib/util/groupTextTokens.js
@@ -1,26 +1,36 @@
 // import getIsTextType from './getIsTextType';
-import Token from './Token';
+import Token from './Token'
+import isSeparatedLink from './isSeparatedLink'
 // import getIsInlineTextType from './getIsInlineTextType';
 
 export default function groupTextTokens(tokens) {
-  const result = [];
-
-  let hasGroup = false;
-  tokens.forEach((token, index) => {
-    if (!token.block && !hasGroup) {
-      hasGroup = true;
-      result.push(new Token('textgroup', 1));
-      result.push(token);
-    } else if (!token.block && hasGroup) {
-      result.push(token);
-    } else if (token.block && hasGroup) {
-      hasGroup = false;
-      result.push(new Token('textgroup', -1));
-      result.push(token);
-    } else {
-      result.push(token);
-    }
-  });
-
-  return result;
+    const result = []
+    let isLinkOpen = false
+    let hasGroup = false
+    tokens.forEach((token, index) => {
+        if (!token.block && !hasGroup && !isLinkOpen) {
+            hasGroup = true
+            result.push(new Token('textgroup', 1))
+            result.push(token)
+        } else if (isSeparatedLink(tokens, token, index)) {
+            // if its a link, close textgroup
+            hasGroup = false
+            result.push(new Token('textgroup', -1))
+            result.push(token)
+            isLinkOpen = true
+        } else if (!token.block && hasGroup) {
+            result.push(token)
+        } else if (token.block && hasGroup) {
+            hasGroup = false
+            result.push(new Token('textgroup', -1))
+            result.push(token)
+        } else {
+            result.push(token)
+        }
+        // closing a link so original code can start new textgroup
+        if (token.type === 'link' && token.nesting === -1) {
+            isLinkOpen = false
+        }
+    })
+    return result
 }

--- a/src/lib/util/isSeparatedLink.js
+++ b/src/lib/util/isSeparatedLink.js
@@ -1,0 +1,23 @@
+const breakingElements = ['softbreak', 'paragraph', 'hardbreak']
+
+// checks if the link should be separated from textgroup
+// if it's not in line with text
+export default function isSeparatedLink(tokens, token, index) {
+    // check if token is a beginning (open tag) of a link
+    if (!(token.type === 'link' && token.nesting === 1)) {
+        return false
+    }
+    // find link closing tag index
+    const closingLinkIndex =
+        tokens
+            .slice(index)
+            .findIndex(x => x.type === 'link' && x.nesting === -1) + index
+    // checking if link is on a line of its own -
+    // starting at beginning of paragraph or after a softbreak, and ends in a softbreak or end of paragraph
+    return (
+        index > 0 &&
+        breakingElements.includes(tokens[index - 1].type) &&
+        closingLinkIndex < tokens.length - 1 &&
+        breakingElements.includes(tokens[closingLinkIndex + 1].type)
+    )
+}


### PR DESCRIPTION
in order to have accessibility to links in text, i prevent grouping them in a textgroup together with text,

* i do that only to links that have a line of their own, to avoid breaking line between text and link in the same line.

to prevent grouping i changed grouping code to close open textgroups when encountering a link which has its own line

having it's own line = has breaking lines before and after or beginning/end of paragraph.

also delete line breaks leftovers after new grouping (closing the textgroup breaks line so create duplicates)